### PR TITLE
Addressing memory issues with the redis service

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,13 +45,16 @@ services:
     command: cron -f
 
   redis:
-    image: redis
+    image: redis:alpine
     container_name: danger_crossing_redis
+    command: sh -c "echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf && redis-server"
     ports:
       - 6379:6379
     volumes:
       - redis-data:/data
-  
+    mem_limit: 1g
+    memswap_limit: 4g
+
 
 volumes:
   acc-dict:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,12 +61,15 @@ services:
     command: cron -f
 
   redis:
-    image: redis
+    image: redis:alpine
     container_name: danger_crossing_redis
+    command: sh -c "echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf && redis-server"
     ports:
       - 6379:6379
     volumes:
       - redis-data:/data
+    mem_limit: 1g
+    memswap_limit: 4g
 
 
 volumes:


### PR DESCRIPTION
I've been running into intermittent issues where the redis service stops working after some intdeterminate amount of time. I'm not completely sure what's going on, but I suspect the service is running out of memory.

In an attempt to resolve, I'm:
  - Providing mem and swap limits to the service, so it can hopefully use swap if it runs out of mem.
  - Adding the vm.overcommit_memory = 1 the configuration.
  - Using the lighter-weight alpine image