### PR TITLE
Configuring vm.overcommit-memory = 1 in the host environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,12 +47,11 @@ services:
   redis:
     image: redis:alpine
     container_name: danger_crossing_redis
-    command: sh -c "echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf && redis-server"
     ports:
       - 6379:6379
     volumes:
       - redis-data:/data
-    mem_limit: 1g
+    mem_limit: 5g
     memswap_limit: 4g
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,12 +63,11 @@ services:
   redis:
     image: redis:alpine
     container_name: danger_crossing_redis
-    command: sh -c "echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf && redis-server"
     ports:
       - 6379:6379
     volumes:
       - redis-data:/data
-    mem_limit: 1g
+    mem_limit: 5g
     memswap_limit: 4g
 
 


### PR DESCRIPTION
I hadn't understood that the vm.overcommit_memory changes need to be made on the host system rather than in the container. As such, there's no need for a convoluted runtime command.

Also significantly uping the mem_limit for the container. If this doesn't do it I might need a beefier VPS.